### PR TITLE
update include directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 mason_packages
 test
 node_modules
+test-Release
+test-Release.dSYM

--- a/Makefile
+++ b/Makefile
@@ -15,13 +15,13 @@ endif
 
 default: test-$(BUILDTYPE)
 
-test-$(BUILDTYPE): tests/unit/* include/hello_world/* Makefile
+test-$(BUILDTYPE): tests/unit/* include/hello_world/hello_world.hpp Makefile
 	$(CXX) $(FINAL_FLAGS) tests/unit/*.cpp $(CXXFLAGS) -o test-$(BUILDTYPE)
 	./test-$(BUILDTYPE)
 
 test: test-$(BUILDTYPE)
 
-SOURCES = $(include/hello_world.hpp)
+SOURCES = $(include/hello_world/hello_world.hpp)
 HEADERS = $(wildcard include/hello_world/*.hpp)
 COMMON_DOC_FLAGS = --report --output docs $(HEADERS)
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ In general, there are three ways to include this header-only library:
 
 ##### Publish to NPM
 
-This repo includes a `package.json` and `.npmignore` that allow for the library to be published to npm. In another project, you can `npm install <PROJECT_NAME> --save` to give yourself access to the `.hpp` files. `hpp-skel` files, for instance, can be found at `node_modules/hpp-skel/include/hello_world.hpp`.
+This repo includes a `package.json` and `.npmignore` that allow for the library to be published to npm. In another project, you can `npm install <PROJECT_NAME> --save` to give yourself access to the `.hpp` files. `hpp-skel` files, for instance, can be found at `node_modules/hpp-skel/include/hello_world/hello_world.hpp`.
 
 The **include_dirs.js** file allows you to include header files using Node.js's `require()` syntax like this:
 

--- a/include/hello_world/hello_world.hpp
+++ b/include/hello_world/hello_world.hpp
@@ -2,4 +2,4 @@
  *
  * Hello World implements a standard namespace with a few available functions.
  */
-#include <hello_world/exclaim.hpp>
+#include "exclaim.hpp"

--- a/tests/unit/hello_world.test.cpp
+++ b/tests/unit/hello_world.test.cpp
@@ -1,4 +1,4 @@
-#include <hello_world.hpp>
+#include <hello_world/hello_world.hpp>
 
 #include <iostream>
 #include <cassert>


### PR DESCRIPTION
Working on the first major release 1.0.0
- changes the include path to be completely within `include/hello_world/` to preserve namespaces and work with mason packaging
