### PR TITLE
Liftoff: Phase 1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/mason.cmake)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -Wsign-compare -Wconversion -Wshadow")
 
+# mason_use is a mason function within the mason.cmake file and provides ready-to-go vars, like "STATIC_LIBS" and "INCLUDE_DIRS"
 mason_use(catch VERSION 1.9.6 HEADER_ONLY)
 include_directories(SYSTEM ${MASON_PACKAGE_catch_INCLUDE_DIRS})
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,21 @@ BUILDTYPE=Release make
 BUILDTYPE=Release make test
 ```
 
+## Customize
+Easily use this skeleton as a starting off point for your own custom project:
+
+```
+# Clone hpp-skel locally
+git clone git@github.com:mapbox/hpp-skel.git
+
+# Create your new repo on GitHub and have the remote repo url handy for liftoff
+# Then run the liftoff script from within your local hpp-skel root directory.
+# This will prompt you for the new name of your project and the new remote repo url, 
+# and it will automatically rename your local hpp-skel directory to the name of your project.
+./scripts/liftoff.sh
+
+```
+
 ## Publishing
 
 We recommend publishing header files to [Mason](https://github.com/mapbox/mason), the C++ packaging manager. Binaries can be downloaded by project name and version number. In order to publish to Mason you must request the publish via a Pull Request to the [`scripts/` directory](https://github.com/mapbox/mason/tree/master/scripts) with your project materials.

--- a/README.md
+++ b/README.md
@@ -36,11 +36,16 @@ Easily use this skeleton as a starting off point for your own custom project:
 ```
 # Clone hpp-skel locally
 git clone git@github.com:mapbox/hpp-skel.git
+cd hpp-skel/
 
 # Create your new repo on GitHub and have the remote repo url handy for liftoff
 # Then run the liftoff script from within your local hpp-skel root directory.
-# This will prompt you for the new name of your project and the new remote repo url, 
-# and it will automatically rename your local hpp-skel directory to the name of your project.
+#
+# This will:
+# - prompt you for the new name of your project and the new remote repo url
+# - automatically rename your local hpp-skel directory to the name of your project
+# - create a new branch called "hpp-skel-port"
+# - add, commit, and push
 ./scripts/liftoff.sh
 
 ```

--- a/scripts/liftoff.sh
+++ b/scripts/liftoff.sh
@@ -1,0 +1,20 @@
+# First create new repo on GitHub
+# Then run the following script from within local hpp-skel directory:
+#
+# liftoff.sh --name <new-name> --url <new-remote-repo-url> 
+#
+
+mv ../hpp-skel $name
+rm -rf .git
+git init
+
+git add .
+git commit -m "here we go"
+git remote add origin $url
+git push -u origin master
+
+# Perhaps useful for fresh start
+# rm -rf include/hello_world
+# rm -rf include/hello_world.hpp
+# cp /dev/null CHANGELOG.md
+# cp /dev/null README.md

--- a/scripts/liftoff.sh
+++ b/scripts/liftoff.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # First create new repo on GitHub
-# Then run the following script from within local hpp-skel directory:
+# Then run the following script from within local hpp-skel root directory:
 #
 # liftoff.sh --name <new-name> --url <new-remote-repo-url> 
 #

--- a/scripts/liftoff.sh
+++ b/scripts/liftoff.sh
@@ -14,10 +14,11 @@ mv ../hpp-skel $name
 rm -rf .git
 git init
 
+git checkout -b hpp-skel-port
 git add .
-git commit -m "here we go"
+git commit -m "Port from hpp-skel"
 git remote add origin $url
-git push -u origin master
+git push -u origin hpp-skel-port
 
 # Perhaps useful for fresh start
 # rm -rf include/hello_world

--- a/scripts/liftoff.sh
+++ b/scripts/liftoff.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # First create new repo on GitHub
 # Then run the following script from within local hpp-skel directory:
 #

--- a/scripts/liftoff.sh
+++ b/scripts/liftoff.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
 
+set -eu
+
 # First create new repo on GitHub
-# Then run the following script from within local hpp-skel root directory:
-#
-# liftoff.sh --name <new-name> --url <new-remote-repo-url> 
-#
+# Then run "./scripts/liftoff.sh" from within your local hpp-skel root directory
+
+echo "What is the name of your new project? "
+read name
+echo "What is the remote repo url for your new project? "
+read url
 
 mv ../hpp-skel $name
 rm -rf .git

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -86,7 +86,9 @@ function run() {
     echo "export ASAN_SYMBOLIZER_PATH=${llvm_toolchain_dir}/bin/llvm-symbolizer" >> ${config}
     echo "export MSAN_SYMBOLIZER_PATH=${llvm_toolchain_dir}/bin/llvm-symbolizer" >> ${config}
     echo "export UBSAN_OPTIONS=print_stacktrace=1" >> ${config}
-    echo "export LSAN_OPTIONS=suppressions=${SUPPRESSION_FILE}" >> ${config}
+    if [[ -f ${SUPPRESSION_FILE} ]]; then
+        echo "export LSAN_OPTIONS=suppressions=${SUPPRESSION_FILE}" >> ${config}
+    fi
     echo "export ASAN_OPTIONS=symbolize=1:abort_on_error=1:detect_container_overflow=1:check_initialization_order=1:detect_stack_use_after_return=1" >> ${config}
     echo 'export MASON_SANITIZE="-fsanitize=address,undefined -fno-sanitize=vptr,function"' >> ${config}
     echo 'export MASON_SANITIZE_CXXFLAGS="${MASON_SANITIZE} -fno-sanitize=vptr,function -fsanitize-address-use-after-scope -fno-omit-frame-pointer -fno-common"' >> ${config}


### PR DESCRIPTION
Per https://github.com/mapbox/hpp-skel/issues/22, super _rough draft_ based on steps I took to rip out the [`gzip`](https://github.com/mapbox/hpp-skel/compare/gzip) branch into its [own repo](https://github.com/mapbox/gzip-hpp). Phase 1, in that, it allowed me to get up and running quickly with a new repo for my specific purposes.

## Next Actions
- [x] Add docs
- [x] Add menu prompt per @springmeyer 's great suggestion

A couple thoughts after doing this with gzip:
- How can devs easily merge future hpp-skel updates? Perhaps this is where forking is handy, but still feels like forking would be too tied to the initial skel. For example, you would have to explicitly enable `Issues` for the new repo to avoid having new Issues being opened in `hpp-skel`. Lots of weird tie-ins that might be too entangled.
- There will likely be a couple different scenarios that users might want for `liftoff`:
  - They have already-existing code (ex: gzip) they want to migrate over to use the best practices/build setup of hpp-skel, allowing them to get up and running fast. In this case they might want to just rip out the example code, reset the readme/changelog, and start fresh.
  - They do not already have code, and perhaps are just learning how to write a header-only lib. In this case, might be nice to create a a new project using the already-existing hello-world example, and iteratively replacing all the pieces as they go (ex: replacing impl code within hello_world methods).

cc @mapbox/core-tech 
