### PR TITLE
glob all sources in test/ directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,4 +12,5 @@ include_directories(SYSTEM ${MASON_PACKAGE_catch_INCLUDE_DIRS})
 
 include_directories("${PROJECT_SOURCE_DIR}/include")
 
-add_executable(unit-tests test/test.cpp)
+file(GLOB TEST_SOURCES test/*.cpp)
+add_executable(unit-tests ${TEST_SOURCES})


### PR DESCRIPTION
This is a minor improvement to the cmake build script. Instead of hardcoding the `test/test.cpp` it moves to globbing the directory. This will make the build more flexible if more test files are added (likely when building out unit tests).

This sets us up to work on #23