### PR TITLE
Disable OS X testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,6 @@ matrix:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
           packages: [ 'libstdc++6', 'libstdc++-5-dev' ]
-    - os: osx
-      osx_image: xcode8.3
 
 env:
   global:


### PR DESCRIPTION
@GretaCB @mapsam and I are setting up for some fast iteration on hpp-skel. This disables OS X testing since 1) we know OS X is working since we develop on it locally and 2) travis is so slow for OS X currently it blocks PRs too often.

Will consider re-enabling once development has slowed down.

/cc @mapsam @GretaCB 