### PR TITLE
Add back -Werror

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,13 @@ set(CMAKE_CXX_STANDARD_REQUIRED on)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/mason.cmake)
 
+option(WERROR "Add -Werror flag to build (turns warnings into errors)" ON)
+
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -Wsign-compare -Wconversion -Wshadow")
+
+if (WERROR)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+endif()
 
 mason_use(catch VERSION 1.9.6 HEADER_ONLY)
 include_directories(SYSTEM ${MASON_PACKAGE_catch_INCLUDE_DIRS})

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,14 @@
+
+# Whether to turn compiler warnings into errors
+export WERROR ?= true
+
 default: release
 
 release:
-	mkdir -p build && cd build && cmake ../ -DCMAKE_BUILD_TYPE=Release && VERBOSE=1 cmake --build .
+	mkdir -p build && cd build && cmake ../ -DCMAKE_BUILD_TYPE=Release -DWERROR=$(WERROR) && VERBOSE=1 cmake --build .
 
 debug:
-	mkdir -p build && cd build && cmake ../ -DCMAKE_BUILD_TYPE=Debug && VERBOSE=1 cmake --build .
+	mkdir -p build && cd build && cmake ../ -DCMAKE_BUILD_TYPE=Debug -DWERROR=$(WERROR) && VERBOSE=1 cmake --build .
 
 test: default 
 	./build/unit-tests

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -3,10 +3,10 @@
 #include <catch.hpp>
 
 TEST_CASE("test version") {
-    REQUIRE(HELLOWORLD_VERSION_STRING == "1.0.0");
+    REQUIRE(HELLOWORLD_VERSION_STRING == std::string("1.0.0"));
 }
 
 TEST_CASE("test_exclaim") {
     std::string value = hello_world::exclaim("hello");
-    REQUIRE(value == "hello!");
+    REQUIRE(value == std::string("hello!"));
 }


### PR DESCRIPTION
This makes all compiler warnings errors again (temporarily lost after #24).

/cc @GretaCB @mapsam 