### PR TITLE
Add clang-tidy integration

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,28 @@
+---
+Checks:          '*'
+WarningsAsErrors: '*'
+HeaderFilterRegex: '\/include\/'
+AnalyzeTemporaryDtors: false
+CheckOptions:    
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             google-readability-namespace-comments.ShortNamespaceLines
+    value:           '10'
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+...
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,15 @@ language: generic
 
 matrix:
   include:
+    # clang-tidy specific job
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources: [ 'ubuntu-toolchain-r-test' ]
+          packages: [ 'libstdc++6', 'libstdc++-5-dev' ]
+      script:
+        - make tidy
     - os: linux
       sudo: false
       env: CXX=g++-5

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.8)
 project(hpp_skel LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED on)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/mason.cmake)
 

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ debug:
 test: default 
 	./build/unit-tests
 
+tidy:
+	./scripts/clang-tidy.sh
+
 coverage:
 	./scripts/coverage.sh
 

--- a/scripts/clang-tidy.sh
+++ b/scripts/clang-tidy.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+# https://clang.llvm.org/extra/clang-tidy/
+
+# to speed up re-runs, only re-create environment if needed
+if [[ ! -f local.env ]]; then
+    # automatically setup environment
+    ./scripts/setup.sh --config local.env
+fi
+
+# source the environment
+source local.env
+
+PATH_TO_CLANG_TIDY_SCRIPT="$(pwd)/mason_packages/.link/share/run-clang-tidy.py"
+
+# to speed up re-runs, only install clang-tidy if needed
+if [[ ! -f PATH_TO_CLANG_TIDY_SCRIPT ]]; then
+    # The MASON_LLVM_RELEASE variable comes from `local.env`
+    mason install clang-tidy ${MASON_LLVM_RELEASE}
+    # We link the tools to make it easy to know ${PATH_TO_CLANG_TIDY_SCRIPT}
+    mason link clang-tidy ${MASON_LLVM_RELEASE}
+fi
+
+# build the compile_commands.json file if it does not exist
+if [[ ! -f build/compile_commands.json ]]; then
+    # the build automatically puts the compile commands in the ./build directory
+    make
+
+fi
+
+# change into the build directory so that clang-tidy can find the files
+# at the right paths (since this is where the actual build happens)
+cd build
+${PATH_TO_CLANG_TIDY_SCRIPT} -fix
+


### PR DESCRIPTION
This addresses #32. This is more simple that the node-cpp-skel implementation (https://github.com/mapbox/node-cpp-skel/pull/64) since `cmake` automatically supports generating the `compile_commands.json` so we don't need this custom hack: https://github.com/mapbox/node-cpp-skel/blob/master/scripts/generate_compile_commands.py

/cc @mapsam @GretaCB 