### PR TITLE
Clang tidy fixes

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          '*'
+Checks:          '*,-cert-err58-cpp'
 WarningsAsErrors: '*'
 HeaderFilterRegex: '\/include\/'
 AnalyzeTemporaryDtors: false

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -2,13 +2,11 @@
 #define CATCH_CONFIG_MAIN
 #include <catch.hpp>
 
-using namespace hello_world;
-
 TEST_CASE("test version") {
     REQUIRE(HELLOWORLD_VERSION_STRING == "1.0.0");
 }
 
 TEST_CASE("test_exclaim") {
-    std::string value = exclaim("hello");
+    std::string value = hello_world::exclaim("hello");
     REQUIRE(value == "hello!");
 }


### PR DESCRIPTION
The clang-tidy support in #32 surfaced a few warnings in the code:

 - the llvm code style prefers system headers to be listed last: `llvm-include-order` | https://clang.llvm.org/extra/clang-tidy/checks/llvm-include-order.html
 - `using namespace` is discouraged: `google-build-using-namespace` | https://clang.llvm.org/extra/clang-tidy/checks/google-build-using-namespace.html
 - initialization of 'autoRegistrar1' with static storage duration may throw an exception that cannot be caught `cert-err58-cpp` | https://clang.llvm.org/extra/clang-tidy/checks/cert-err58-cpp.html

Exact errors were:

```
clang-tidy -header-filter=^/Users/dane/projects/hpp-skel/build/.* -export-fixes /var/folders/jv/bhkldrpj41jbkpzxgc9ggr_r0000gn/T/tmpx2a7SD/tmpr_Hgl6.yaml -p=/Users/dane/projects/hpp-skel/build /Users/dane/projects/hpp-skel/test/test.cpp
7471 warnings generated.
/Users/dane/projects/hpp-skel/test/test.cpp:3:1: error: #includes are not sorted properly [llvm-include-order,-warnings-as-errors]
#include <iostream>
^
/Users/dane/projects/hpp-skel/test/test.cpp:6:1: error: do not use namespace using-directives; use using-declarations instead [google-build-using-namespace,-warnings-as-errors]
using namespace hello_world;
^
/Users/dane/projects/hpp-skel/test/test.cpp:7:1: error: initialization of 'autoRegistrar1' with static storage duration may throw an exception that cannot be caught [cert-err58-cpp,-warnings-as-errors]
TEST_CASE("test version") {
^
```

/cc @GretaCB @mapsam 