### PR TITLE
Add clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,88 @@
+---
+# Mapbox.Variant C/C+ style
+Language:        Cpp
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: false
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass:      true
+  AfterControlStatement: true
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: true
+  AfterStruct:     true
+  AfterUnion:      true
+  BeforeCatch:     true
+  BeforeElse:      true
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+ColumnLimit:     0
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IndentCaseLabels: false
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        4
+UseTab:          Never

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ build
 *.profdata
 *.profraw
 .toolchain
+.mason
+local.env

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,14 +25,13 @@ matrix:
           packages: [ 'libstdc++6', 'libstdc++-5-dev' ]
     # Clang format build
     - os: linux
-      language: generic
-      env: BUILDTYPE=debug
-      node_js: 4
-      # Overrides `install` to avoid initializing clang toolchain
-      install: 
-        - ./scripts/format.sh
-      # Overrides `script`, no need to run tests
-      before_script:
+      sudo: false
+      addons:
+        apt:
+          sources: [ 'ubuntu-toolchain-r-test' ]
+          packages: [ 'libstdc++6', 'libstdc++-5-dev' ]
+      script:
+        - make format
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,16 @@ matrix:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
           packages: [ 'libstdc++6', 'libstdc++-5-dev' ]
+    # Clang format build
+    - os: linux
+      language: generic
+      env: BUILDTYPE=debug
+      node_js: 4
+      # Overrides `install` to avoid initializing clang toolchain
+      install: 
+        - ./scripts/format.sh
+      # Overrides `script`, no need to run tests
+      before_script:
 
 env:
   global:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 08/25/2017
 
+* Add clang-format
+* Transition tests to use catch
 * [Port to cmake](https://github.com/mapbox/hpp-skel/pull/24)
 * [Add setup.sh and local coverage reporting](https://github.com/mapbox/hpp-skel/pull/27)
 * Add [first iteration](https://github.com/mapbox/hpp-skel/pull/29) of "liftoff" script

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,4 @@
+# Developer
+
+We use [`clang-format`](https://clang.llvm.org/docs/ClangFormat.html) version [4.0.0](https://github.com/mapbox/mason/tree/master/scripts/clang-format) to consistently format the code base. The format is automatically checked via a Travis CI build as well. Run the following script locally to ensure formatting is ready to merge:
+`./scripts/format.sh`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
 # Developer
 
 We use [`clang-format`](https://clang.llvm.org/docs/ClangFormat.html) version [4.0.0](https://github.com/mapbox/mason/tree/master/scripts/clang-format) to consistently format the code base. The format is automatically checked via a Travis CI build as well. Run the following script locally to ensure formatting is ready to merge:
-`./scripts/format.sh`
+`make format`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
 # Developer
 
-We use [`clang-format`](https://clang.llvm.org/docs/ClangFormat.html) version [4.0.0](https://github.com/mapbox/mason/tree/master/scripts/clang-format) to consistently format the code base. The format is automatically checked via a Travis CI build as well. Run the following script locally to ensure formatting is ready to merge:
+We use [this](https://github.com/mapbox/hpp-skel/blob/master/scripts/setup.sh#L7%60) current [`clang-format`](https://clang.llvm.org/docs/ClangFormat.html) version to consistently format the code base. The format is automatically checked via a Travis CI build as well. Run the following script locally to ensure formatting is ready to merge:
 `make format`

--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,6 @@ coverage:
 
 clean:
 	rm -rf build
+
+format:
+	./scripts/format.sh

--- a/include/hello_world.hpp
+++ b/include/hello_world.hpp
@@ -2,5 +2,5 @@
  *
  * Hello World implements a standard namespace with a few available functions.
  */
-#include "hello_world/version.hpp"
 #include "hello_world/exclaim.hpp"
+#include "hello_world/version.hpp"

--- a/include/hello_world/exclaim.hpp
+++ b/include/hello_world/exclaim.hpp
@@ -9,7 +9,7 @@ namespace hello_world {
  *
  * @return your message with an exclamation point on each end.
  */
-std::string exclaim (std::string message)
+std::string exclaim(std::string message)
 {
     std::string response = message + "!";
     return response;

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+: '
+
+Runs clang-format on the code in include/
+
+Return `1` if there are files to be formatted, and automatically formats them.
+
+Returns `0` if everything looks properly formatted.
+
+'
+ # Set up the environment by installing mason and clang++
+ # See https://github.com/mapbox/node-cpp-skel/blob/master/docs/extended-tour.md#configuration-files
+./scripts/setup.sh --config local.env
+source local.env
+
+# Add clang-format as a dep
+mason install clang-format ${MASON_LLVM_RELEASE}
+mason link clang-format ${MASON_LLVM_RELEASE}
+
+# Run clang-format on all cpp and hpp files in the /src directory
+find include/ -type f -name '*.hpp' \
+ | xargs -I{} clang-format -i -style=file {}
+
+# Print list of modified files
+dirty=$(git ls-files --modified include/)
+
+if [[ $dirty ]]; then
+    echo "The following files have been modified:"
+    echo $dirty
+    exit 1
+else
+    exit 0
+fi

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -13,7 +13,6 @@ Returns `0` if everything looks properly formatted.
 
 '
  # Set up the environment by installing mason and clang++
- # See https://github.com/mapbox/node-cpp-skel/blob/master/docs/extended-tour.md#configuration-files
 ./scripts/setup.sh --config local.env
 source local.env
 


### PR DESCRIPTION
Per https://github.com/mapbox/hpp-skel/issues/31

### Next Actions
- [x] Add `.clang-format`
- [x] Add `./scripts/format.sh`
- [x] Run `./scripts/format.sh` against hpp-skel code
- [x] Add clang-format Travis build
- [x] Add CONTRIBUTING.md
- [x] Update `.gitignore` per installing clang-format
- [x] Update CHANGELOG.md
- [x] Code Review
- [x] Merge after Travis is 🍏 

cc @springmeyer @mapsam 