### PR TITLE
[WIP] Add Benchmarks: Phase 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ matrix:
 env:
   global:
    - CMAKE_VERSION="3.8.2"
+   - BENCHMARK_VERSION="1.2.0"
 
 install:
   # set up the environment by installing mason and clang++
@@ -70,6 +71,8 @@ install:
   - source local.env
   - mason install cmake ${CMAKE_VERSION}
   - mason link cmake ${CMAKE_VERSION}
+  - mason install benchmark ${BENCHMARK_VERSION}
+  - mason link benchmark ${BENCHMARK_VERSION}
   - which cmake
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,6 @@ matrix:
 env:
   global:
    - CMAKE_VERSION="3.8.2"
-   - BENCHMARK_VERSION="1.2.0"
 
 install:
   # set up the environment by installing mason and clang++
@@ -71,8 +70,6 @@ install:
   - source local.env
   - mason install cmake ${CMAKE_VERSION}
   - mason link cmake ${CMAKE_VERSION}
-  - mason install benchmark ${BENCHMARK_VERSION}
-  - mason link benchmark ${BENCHMARK_VERSION}
   - which cmake
 
 script:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,16 @@ endif()
 mason_use(catch VERSION 1.9.6 HEADER_ONLY)
 include_directories(SYSTEM ${MASON_PACKAGE_catch_INCLUDE_DIRS})
 
+mason_use(benchmark VERSION 1.2.0)
+include_directories(SYSTEM ${MASON_PACKAGE_benchmark_INCLUDE_DIRS})
+
 include_directories("${PROJECT_SOURCE_DIR}/include")
 
 file(GLOB TEST_SOURCES test/*.cpp)
 add_executable(unit-tests ${TEST_SOURCES})
+
+file(GLOB BENCH_SOURCES bench/*.cpp)
+add_executable(bench-tests ${BENCH_SOURCES})
+
+# link benchmark static library to the bench-tests binary so the bench tests know where to find the benchmark impl code
+target_link_libraries(bench-tests ${MASON_PACKAGE_benchmark_STATIC_LIBS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,8 +37,10 @@ include_directories("${PROJECT_SOURCE_DIR}/include")
 file(GLOB TEST_SOURCES test/*.cpp)
 add_executable(unit-tests ${TEST_SOURCES})
 
+# libbenchmark.a supports threads and therefore needs pthread support
+find_package(Threads REQUIRED)
 file(GLOB BENCH_SOURCES bench/*.cpp)
 add_executable(bench-tests ${BENCH_SOURCES})
 
 # link benchmark static library to the bench-tests binary so the bench tests know where to find the benchmark impl code
-target_link_libraries(bench-tests ${MASON_PACKAGE_benchmark_STATIC_LIBS})
+target_link_libraries(bench-tests ${MASON_PACKAGE_benchmark_STATIC_LIBS} ${CMAKE_THREAD_LIBS_INIT})

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ test:
 	@if [ -f ./build/unit-tests ]; then ./build/unit-tests; else echo "Please run 'make release' or 'make debug' first" && exit 1; fi
 
 bench:
-	./build/bench-tests
+	@if [ -f ./build/bench-tests ]; then ./build/bench-tests; else echo "Please run 'make release' or 'make debug' first" && exit 1; fi
 
 tidy:
 	./scripts/clang-tidy.sh
@@ -28,4 +28,4 @@ clean:
 format:
 	./scripts/format.sh
 
-.PHONY: test
+.PHONY: test bench

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ debug:
 test:
 	@if [ -f ./build/unit-tests ]; then ./build/unit-tests; else echo "Please run 'make release' or 'make debug' first" && exit 1; fi
 
+bench:
+	./build/bench-tests
+
 tidy:
 	./scripts/clang-tidy.sh
 

--- a/bench/bench.cpp
+++ b/bench/bench.cpp
@@ -1,0 +1,11 @@
+#include <benchmark/benchmark.h>
+#include <hello_world.hpp>
+
+static void BM_exclaim(benchmark::State& state) {
+  while (state.KeepRunning())
+    std::string value = hello_world::exclaim("hello");
+}
+// Register the function as a benchmark
+BENCHMARK(BM_exclaim);
+
+BENCHMARK_MAIN();

--- a/bench/bench.cpp
+++ b/bench/bench.cpp
@@ -9,4 +9,4 @@ static void BM_exclaim(benchmark::State& state) {
 // Register the function as a benchmark
 BENCHMARK(BM_exclaim);
 
-BENCHMARK_MAIN();
+BENCHMARK_MAIN()

--- a/bench/bench.cpp
+++ b/bench/bench.cpp
@@ -4,7 +4,7 @@
 static void BM_exclaim(benchmark::State& state) {
   while (state.KeepRunning()) {
     std::string value = hello_world::exclaim("hello");
-}
+  }
 }
 // Register the function as a benchmark
 BENCHMARK(BM_exclaim);

--- a/bench/bench.cpp
+++ b/bench/bench.cpp
@@ -2,8 +2,9 @@
 #include <hello_world.hpp>
 
 static void BM_exclaim(benchmark::State& state) {
-  while (state.KeepRunning())
+  while (state.KeepRunning()) {
     std::string value = hello_world::exclaim("hello");
+}
 }
 // Register the function as a benchmark
 BENCHMARK(BM_exclaim);


### PR DESCRIPTION
Per https://github.com/mapbox/hpp-skel/issues/33, make our code measurable 🙌 

- This PR uses [google's benchmark](https://github.com/google/benchmark) lib via Mason. @springmeyer Do you have any preference between `chrono` and google/benchmark (I'm assuming they're analogous?
- Currently only a single baby benchmark, since there isn't much to measure with the sync `exclaim` function. But per ticket above, going to expand this for Phase 2

cc @mapsam 