### PR TITLE
Do not sort includes with clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -72,7 +72,7 @@ PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Left
 ReflowComments:  true
-SortIncludes:    true
+SortIncludes: false
 SpaceAfterCStyleCast: false
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeParens: ControlStatements


### PR DESCRIPTION
There are select times where the ordering of includes can be very important for a variety of reasons. While we seek to avoid these problems in our libraries and software, sometimes when depending on external libraries this can become very important. Therefore, I suggest that we do not sort includes with clang format by default. 

/cc @artemp @springmeyer @GretaCB 