### PR TITLE
Upgrade deps

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,9 +1,11 @@
 ---
-Checks:          '*,-cert-err58-cpp'
+# clang-analyzer-core.uninitialized.UndefReturn can be removed once LLVM is upgrade to fix
+# https://bugs.llvm.org/show_bug.cgi?id=39201
+Checks:          '*,-clang-analyzer-core.uninitialized.UndefReturn'
 WarningsAsErrors: '*'
 HeaderFilterRegex: '\/include\/'
 AnalyzeTemporaryDtors: false
-CheckOptions:    
+CheckOptions:
   - key:             google-readability-braces-around-statements.ShortStatementLines
     value:           '1'
   - key:             google-readability-function-size.StatementThreshold
@@ -25,4 +27,3 @@ CheckOptions:
   - key:             modernize-use-nullptr.NullMacros
     value:           'NULL'
 ...
-

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,7 @@
 ---
 # clang-analyzer-core.uninitialized.UndefReturn can be removed once LLVM is upgrade to fix
 # https://bugs.llvm.org/show_bug.cgi?id=39201
-Checks:          '*,-clang-analyzer-core.uninitialized.UndefReturn'
+Checks:          '*,-fuchsia-default-arguments,-clang-analyzer-core.uninitialized.UndefReturn'
 WarningsAsErrors: '*'
 HeaderFilterRegex: '\/include\/'
 AnalyzeTemporaryDtors: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,10 +32,10 @@ if (WERROR)
 endif()
 
 # mason_use is a mason function within the mason.cmake file and provides ready-to-go vars, like "STATIC_LIBS" and "INCLUDE_DIRS"
-mason_use(catch VERSION 1.9.6 HEADER_ONLY)
+mason_use(catch VERSION 2.4.0 HEADER_ONLY)
 include_directories(SYSTEM ${MASON_PACKAGE_catch_INCLUDE_DIRS})
 
-mason_use(benchmark VERSION 1.2.0)
+mason_use(benchmark VERSION 1.4.1)
 include_directories(SYSTEM ${MASON_PACKAGE_benchmark_INCLUDE_DIRS})
 
 include_directories("${PROJECT_SOURCE_DIR}/include")

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -3,8 +3,8 @@
 set -eu
 set -o pipefail
 
-export MASON_RELEASE="${_MASON_RELEASE:-v0.18.0}"
-export MASON_LLVM_RELEASE="${_MASON_LLVM_RELEASE:-5.0.1}"
+export MASON_RELEASE="${_MASON_RELEASE:-v0.19.0}"
+export MASON_LLVM_RELEASE="${_MASON_LLVM_RELEASE:-7.0.0}"
 
 PLATFORM=$(uname | tr A-Z a-z)
 if [[ ${PLATFORM} == 'darwin' ]]; then
@@ -38,9 +38,6 @@ function run() {
     if [[ -d ${GLOBAL_LLVM} ]]; then
       echo "Detected '${GLOBAL_LLVM}/bin/clang++', using it"
       local llvm_toolchain_dir=${GLOBAL_LLVM}
-    elif [[ -d ${GLOBAL_CLANG} ]]; then
-      echo "Detected '${GLOBAL_CLANG}/bin/clang++', using it"
-      local llvm_toolchain_dir=${GLOBAL_CLANG}
     elif [[ -d ${GLOBAL_CLANG} ]]; then
       echo "Detected '${GLOBAL_CLANG}/bin/clang++', using it"
       local llvm_toolchain_dir=${GLOBAL_CLANG}


### PR DESCRIPTION
This upgrades to:

 - LLVM v7
 - Catch v2.4.0
 - Benchmark v1.4.1
 - Mason v0.19.0

Disables a clang-tidy warning due to https://github.com/catchorg/Catch2/issues/1230